### PR TITLE
Explicitly include docker service in security check

### DIFF
--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -1,7 +1,13 @@
+variables:
+  - DOCKER_VERSION: 24.0.6-dind
+
 container_scanning:
   tags:
-    - low-load
+    - small-runner
   stage: test
+  services:
+    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+      alias: docker
   variables:
     TRIVY_NO_PROGRESS: "true"
     # Set to "backend" and "frontend" in the respective jobs in mono-repos.

--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -1,12 +1,12 @@
 variables:
-  - DOCKER_VERSION: 24.0.6-dind
+  - DOCKER_VERSION: 24.0.6
 
 container_scanning:
   tags:
     - small-runner
   stage: test
   services:
-    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}-dind
       alias: docker
   variables:
     TRIVY_NO_PROGRESS: "true"


### PR DESCRIPTION
- Define a DOCKER_VERSION variable that will be overridden in project's main gitlab-ci.yaml
- Explicitly include the service definition for docker in case project doesn't usually use docker