### PR TITLE
feat: run trivy as image instead of downloading manually

### DIFF
--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -10,7 +10,8 @@ container_scanning:
     TRIVY_USERNAME: "$CI_REGISTRY_USER"
     TRIVY_PASSWORD: "$CI_REGISTRY_PASSWORD"
     TRIVY_AUTH_URL: "$CI_REGISTRY"
-    TRIVY_SEVERITY: "HIGH,CRITICAL"
+    SEVERITY: "HIGH,CRITICAL"
+    TRIVY_SEVERITY: "$SEVERITY"    
     TRIVY_CACHE_DIR: ".trivycache/"
     # Set to "backend" and "frontend" in the respective jobs in mono-repos.
     DIRECTORY: "./"

--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -1,6 +1,3 @@
-variables:
-  - DOCKER_VERSION: 24.0.6
-
 container_scanning:
   image: 
     name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy

--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -3,7 +3,7 @@ variables:
 
 container_scanning:
   image: 
-    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy:0.47.0
+    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy
     entrypoint: [""]
   tags:
     - small-runner
@@ -16,25 +16,27 @@ container_scanning:
     TRIVY_USERNAME: "$CI_REGISTRY_USER"
     TRIVY_PASSWORD: "$CI_REGISTRY_PASSWORD"
     TRIVY_AUTH_URL: "$CI_REGISTRY"
+    TRIVY_SEVERITY: "HIGH,CRITICAL"
+    TRIVY_CACHE_DIR: ".trivycache/"
     # Set to "backend" and "frontend" in the respective jobs in mono-repos.
     DIRECTORY: "./"
     # Is like that for backward-compatibility, previously we only had DIRECTORY.
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
-    TRIVY_CACHE_DIR: ".trivycache/"
-    SEVERITY: "HIGH,CRITICAL"
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
     - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   allow_failure: true
   script:
-    # Image report
-    - trivy image --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >/dev/null 2>&1 || true
-    # Filesystem report
-    - trivy filesystem --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >/dev/null 2>&1 || true
+    # Image report (Operating System Vulnerabilities)
+    - trivy image --exit-code 0 --ignore-unfixed --scanners vuln --vuln-type os --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >/dev/null 2>&1 || true
+    # Filesystem report (Source Dependency Vulnerabilities)
+    - trivy filesystem --exit-code 0 --ignore-unfixed --scanners config,vuln --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >/dev/null 2>&1 || true
     # Report results as table
-    - trivy image --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format table $IMAGE || IMAGE_CODE=$?
-    - trivy filesystem --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --dependency-tree --format table $DIRECTORY || FILE_CODE=$?
+    # Image report (Operating System Vulnerabilities)
+    - trivy image --exit-code 1 --ignore-unfixed --scanners vuln --vuln-type os --format table $IMAGE || IMAGE_CODE=$?
+    # Filesystem report (Source Dependency Vulnerabilities)
+    - trivy filesystem --exit-code 1 --ignore-unfixed --scanners config,vuln --dependency-tree --format table $DIRECTORY || FILE_CODE=$?
     # Combine report
     - apk update && apk add jq sed
     - jq -s 'add' gl-codeclimate-image.json gl-codeclimate-fs.json > ${FILENAME}

--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -8,9 +8,6 @@ container_scanning:
   tags:
     - small-runner
   stage: test
-  services:
-    - name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
-      alias: docker
   variables:
     TRIVY_NO_PROGRESS: "true"
     TRIVY_USERNAME: "$CI_REGISTRY_USER"
@@ -24,8 +21,6 @@ container_scanning:
     FILENAME: "gl-codeclimate-$CI_JOB_NAME_SLUG.json"
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
-    - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   allow_failure: true
   script:
     # Image report (Operating System Vulnerabilities)

--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -2,7 +2,9 @@ variables:
   - DOCKER_VERSION: 24.0.6
 
 container_scanning:
-  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/docker:${DOCKER_VERSION}
+  image: 
+    name: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/aquasec/trivy:0.47.0
+    entrypoint: [""]
   tags:
     - small-runner
   stage: test
@@ -11,6 +13,9 @@ container_scanning:
       alias: docker
   variables:
     TRIVY_NO_PROGRESS: "true"
+    TRIVY_USERNAME: "$CI_REGISTRY_USER"
+    TRIVY_PASSWORD: "$CI_REGISTRY_PASSWORD"
+    TRIVY_AUTH_URL: "$CI_REGISTRY"
     # Set to "backend" and "frontend" in the respective jobs in mono-repos.
     DIRECTORY: "./"
     # Is like that for backward-compatibility, previously we only had DIRECTORY.
@@ -19,23 +24,20 @@ container_scanning:
     SEVERITY: "HIGH,CRITICAL"
   before_script:
     - if [ ! -e ${TRIVY_CACHE_DIR} ]; then mkdir -p ${TRIVY_CACHE_DIR}; fi
-    - export TRIVY_VERSION=$(wget -qO - "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-    - echo $TRIVY_VERSION
-    - if [ ! -e ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz ]; then wget --no-verbose https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -O ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz; fi
-    - tar -zxvf ${TRIVY_CACHE_DIR}trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz -C .
     - until docker info; do sleep 1; done # Mitigate GitLab-Runner not setting up DinD in time, see: https://gitlab.com/gitlab-org/gitlab/-/issues/354744
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   allow_failure: true
   script:
     # Image report
-    - ./trivy image --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >/dev/null 2>&1 || true
+    - trivy image --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >/dev/null 2>&1 || true
     # Filesystem report
-    - ./trivy filesystem --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >/dev/null 2>&1 || true
+    - trivy filesystem --exit-code 0 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >/dev/null 2>&1 || true
+    # Report results as table
+    - trivy image --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format table $IMAGE || IMAGE_CODE=$?
+    - trivy filesystem --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --dependency-tree --format table $DIRECTORY || FILE_CODE=$?
     # Combine report
     - apk update && apk add jq sed
     - jq -s 'add' gl-codeclimate-image.json gl-codeclimate-fs.json > ${FILENAME}
-    - ./trivy image --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners vuln --vuln-type os --format table $IMAGE || IMAGE_CODE=$?
-    - ./trivy filesystem --exit-code 1 --ignore-unfixed --severity $SEVERITY --scanners config,vuln --dependency-tree --format table $DIRECTORY || FILE_CODE=$?
     - exit $((IMAGE_CODE+FILE_CODE))
   cache:
     paths:


### PR DESCRIPTION
Reduce complexity by using the official docker image as the CI job image instead of downloading by hand