### PR TITLE
Use absolute path for contrib-template

### DIFF
--- a/security-checks.yaml
+++ b/security-checks.yaml
@@ -22,9 +22,9 @@ container_scanning:
   allow_failure: true
   script:
     # Image report (Operating System Vulnerabilities)
-    - trivy image --exit-code 0 --ignorefile ./.trivyignore.yaml --ignore-unfixed --scanners vuln --vuln-type os --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >trivy-image.log 2>&1 || true
+    - trivy image --exit-code 0 --ignorefile ./.trivyignore.yaml --ignore-unfixed --scanners vuln --vuln-type os --format template --template "@/contrib/gitlab-codequality.tpl" -o gl-codeclimate-image.json $IMAGE >trivy-image.log 2>&1 || true
     # Filesystem report (Source Dependency Vulnerabilities)
-    - trivy filesystem --exit-code 0 --ignorefile ./.trivyignore.yaml --ignore-unfixed --scanners misconfig,vuln --format template --template "@contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >trivy-fs.log 2>&1 || true
+    - trivy filesystem --exit-code 0 --ignorefile ./.trivyignore.yaml --ignore-unfixed --scanners misconfig,vuln --format template --template "@/contrib/gitlab-codequality.tpl" -o gl-codeclimate-fs.json $DIRECTORY >trivy-fs.log 2>&1 || true
     # Report results as table
     # Image report (Operating System Vulnerabilities)
     - trivy image --exit-code 1 --ignorefile ./.trivyignore.yaml --ignore-unfixed --scanners vuln --vuln-type os --format table $IMAGE || IMAGE_CODE=$?


### PR DESCRIPTION
The contrib templates that are part of the trivy image are located at /contrib within the image and the default working directory is /. 

Instructions at trivy do not mention that the template is in fact not taken from within the binary or some artifact storage, but from the local filesystem.

GitLab runners change the working directory to a folder named after the project-slug and therefore the paths for any files inside the trivy image have to be specified as absolute paths instead.